### PR TITLE
Initialize pnpm workspace with frontend and backend apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+pnpm-lock.yaml

--- a/packages/nest-prisma-ts/.gitignore
+++ b/packages/nest-prisma-ts/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.prisma/
+.env

--- a/packages/nest-prisma-ts/package.json
+++ b/packages/nest-prisma-ts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "nest-prisma-ts",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.2",
+    "@nestjs/core": "^10.3.2",
+    "@nestjs/platform-express": "^10.3.2",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "@prisma/client": "^5.9.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.2",
+    "@nestjs/schematics": "^10.3.2",
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.1",
+    "prisma": "^5.9.1"
+  }
+}

--- a/packages/nest-prisma-ts/prisma/schema.prisma
+++ b/packages/nest-prisma-ts/prisma/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/packages/nest-prisma-ts/src/app.module.ts
+++ b/packages/nest-prisma-ts/src/app.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class AppModule {}

--- a/packages/nest-prisma-ts/src/main.ts
+++ b/packages/nest-prisma-ts/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/packages/nest-prisma-ts/tsconfig.json
+++ b/packages/nest-prisma-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/vite-react-ts/.gitignore
+++ b/packages/vite-react-ts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/vite-react-ts/index.html
+++ b/packages/vite-react-ts/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/vite-react-ts/package.json
+++ b/packages/vite-react-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vite-react-ts",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "typescript": "^5.3.3",
+    "@types/react": "^18.2.17",
+    "@types/react-dom": "^18.2.7"
+  }
+}

--- a/packages/vite-react-ts/src/App.tsx
+++ b/packages/vite-react-ts/src/App.tsx
@@ -1,0 +1,5 @@
+function App() {
+  return <h1>Hello Vite + React!</h1>;
+}
+
+export default App;

--- a/packages/vite-react-ts/src/main.tsx
+++ b/packages/vite-react-ts/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/vite-react-ts/tsconfig.json
+++ b/packages/vite-react-ts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/packages/vite-react-ts/vite.config.ts
+++ b/packages/vite-react-ts/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- add pnpm-workspace with `packages/*`
- scaffold `vite-react-ts` React frontend
- scaffold `nest-prisma-ts` backend with Prisma

## Testing
- `pnpm install` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683fde4d9ab08326bad481978b6fe86f